### PR TITLE
switch passing local location to global location

### DIFF
--- a/cubesat_ui_panel.py
+++ b/cubesat_ui_panel.py
@@ -68,7 +68,7 @@ class VIEW3D_PT_cubesat(bpy.types.Panel):
         col.label(text=f'x:{round(acc.x, 3)} y:{round(acc.y, 3)} z:{round(acc.z, 3)}')
 
         # Readout of magnetic properties
-        magf = mag.get_magnetic_force(bpy.data.objects['cubesat'].location)
+        magf = mag.get_magnetic_force(bpy.data.objects['cubesat'].matrix_world @ bpy.data.objects['cubesat'].location)
         col = layout.column(align=True)
         col.label(text= "North component:")
         col.label(text='{:>+10.3f}'.format(magf[0]))


### PR DESCRIPTION
Currently mag_calc is passed bpy.data.objects['cubesat'].location which returns the local space location of cubesat, currently 0,0,0 in simulation.blend. This results in mag_calc calculating altitude to be -635.7. Changed to pass the global space location of the cubesat instead